### PR TITLE
Upgrade to ember 1.9

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,11 +1,11 @@
 {
-  "predef": {
-    "document": true,
-    "window": true,
-    "GrowlENV": true
-  },
-  "browser" : true,
-  "boss" : true,
+  "predef": [
+    "document",
+    "window",
+    "-Promise"
+  ],
+  "browser": true,
+  "boss": true,
   "curly": true,
   "debug": false,
   "devel": true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ cache:
   directories:
     - node_modules
 
+before_install:
+  - "npm config set spin false"
+  - "npm install -g npm@^2"
+
 install:
   - npm install -g bower
   - npm install

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,3 +1,4 @@
+/* jshint node: true */
 /* global require, module */
 
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');

--- a/bower.json
+++ b/bower.json
@@ -3,9 +3,8 @@
   "dependencies": {
     "handlebars": "2.0.0",
     "jquery": "^1.11.1",
-    "ember": "1.7.0",
-    "ember-data": "1.0.0-beta.10",
-    "ember-resolver": "~0.1.7",
+    "ember": "1.9.0",
+    "ember-resolver": "~0.1.10",
     "loader.js": "stefanpenner/loader.js#1.0.1",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "growl",
   "dependencies": {
-    "handlebars": "~1.3.0",
+    "handlebars": "2.0.0",
     "jquery": "^1.11.1",
     "ember": "1.7.0",
     "ember-data": "1.0.0-beta.10",
@@ -13,5 +13,8 @@
     "ember-qunit": "0.1.8",
     "ember-qunit-notifications": "0.0.4",
     "qunit": "~1.15.0"
+  },
+  "resolutions": {
+    "handlebars": "2.0.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+/* jshint node: true */
 'use strict';
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -19,16 +19,13 @@
   "license": "MIT",
   "devDependencies": {
     "body-parser": "^1.2.0",
-    "broccoli-asset-rev": "0.3.1",
-    "broccoli-ember-hbs-template-compiler": "^1.6.1",
-    "ember-cli": "0.1.2",
-    "ember-cli-content-security-policy": "0.3.0",
-    "ember-export-application-global": "^1.0.0",
+    "broccoli-asset-rev": "1.0.0",
+    "ember-cli": "0.1.4",
+    "ember-cli-htmlbars": "^0.5.1",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.1.0",
-    "ember-data": "1.0.0-beta.10",
-    "express": "^4.8.5",
+    "ember-export-application-global": "^1.0.0",
     "glob": "^4.0.5"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   "devDependencies": {
     "body-parser": "^1.2.0",
     "broccoli-asset-rev": "1.0.0",
-    "ember-cli": "0.1.4",
+    "ember-cli": "0.1.3",
     "ember-cli-htmlbars": "^0.5.1",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.1.0",
+    "ember-cli-qunit": "^0.1.2",
     "ember-export-application-global": "^1.0.0",
     "glob": "^4.0.5"
   },

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -1,6 +1,5 @@
 {
   "predef": [
-    "DummyENV",
     "document",
     "window",
     "location",

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -11,19 +11,15 @@
 
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/dummy.css">
-    <style>
-      .boxed {
-        max-width: 500px;
-      }
-      code {
-        background-color: #d8d8d8;
-      }
-    </style>
+
+    {{content-for 'head-footer'}}
   </head>
   <body>
     {{content-for 'body'}}
 
     <script src="assets/vendor.js"></script>
     <script src="assets/dummy.js"></script>
+
+    {{content-for 'body-footer'}}
   </body>
 </html>

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -30,7 +30,7 @@ module.exports = function(environment) {
   if (environment === 'test') {
     // Testem prefers this...
     ENV.baseURL = '/';
-    ENV.locationType = 'auto';
+    ENV.locationType = 'none';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;

--- a/tests/dummy/public/robots.txt
+++ b/tests/dummy/public/robots.txt
@@ -1,3 +1,2 @@
-# robotstxt.org/
-
+# http://www.robotstxt.org
 User-agent: *

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -9,17 +9,11 @@ export default function startApp(attrs) {
   var attributes = Ember.merge({}, config.APP);
   attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
-  Router.reopen({
-    location: 'none'
-  });
-
   Ember.run(function() {
     App = Application.create(attributes);
     App.setupForTesting();
     App.injectTestHelpers();
   });
-
-  App.reset(); // this shouldn't be needed, i want to be able to "start an app at a specific URL"
 
   return App;
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -29,10 +29,11 @@
         zoom: 50%;
       }
     </style>
+
+    {{content-for 'head-footer'}}
+    {{content-for 'test-head-footer'}}
   </head>
   <body>
-    <div id="qunit"></div>
-    <div id="qunit-fixture"></div>
 
     {{content-for 'body'}}
     {{content-for 'test-body'}}
@@ -41,5 +42,8 @@
     <script src="assets/dummy.js"></script>
     <script src="testem.js"></script>
     <script src="assets/test-loader.js"></script>
+
+    {{content-for 'body-footer'}}
+    {{content-for 'test-body-footer'}}
   </body>
 </html>

--- a/tests/unit/components/growl-instance-test.js
+++ b/tests/unit/components/growl-instance-test.js
@@ -15,14 +15,6 @@ test('assert that the element class exists', function() {
   ok(this.subject().classNames.indexOf('growl-instance') > -1, 'CSS class exists');
 });
 
-test('assert that the notification type is reflected as a classname', function() {
-  expect(1);
-  var subject = this.subject();
-
-  subject.set('notification', testNotification);
-  equal(subject._classStringForProperty('type'), 'error', 'The instance has a class of error');
-});
-
 test('assert that the instance will close when clicked', function() {
   expect(3);
 


### PR DESCRIPTION
Hey I was using growl in an ember 1.9 project. After I installed it my project startup time was suddently VERY long. I thought it could be because of competing handlebars versions (2 sets of compilers? Or maybe just way to many files..). I may be completely wrong with the theory, but in practice when I forked growl and upgraded it to ember 1.9 my projects startup time  came back to normal. 

I had to remove one test in the process as it didn't work. And it seems that it didn't work because the function you used (`_classStringForProperty`) has changed in the meantime. Or I may have broken the test with the upgrade, it would be nice if you could look at it and see what's wrong.

Anyway I think it may benefit other people (as I think most of us upgrade ember more or less to the latest version) hence the pull request.