### PR TITLE
removes deprecated context switching form of {{each}}

### DIFF
--- a/app/templates/components/growl-manager.hbs
+++ b/app/templates/components/growl-manager.hbs
@@ -1,4 +1,4 @@
 
-{{#each notifications}}
-  {{growl-instance action="dismiss" notification=this}}
+{{#each notification in notifications}}
+  {{growl-instance action="dismiss" notification=notification}}
 {{/each}}


### PR DESCRIPTION
using ember-cli-growl plugin in one of our apps; we're seeing the Deprecation warnings about the {{each}} statement in the manager.  Simple update to add the "in" and replace the "this" context.