### PR TITLE
Making ember-cli from 2.4.3 be able to resolve the css file

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,6 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import('components/growl-manager.css');
+    app.import('app/styles/components/growl-manager.css');
   }
 };


### PR DESCRIPTION
After upgrading ember and ember-cli to 2.4.3 I got the following error when building:

```
Build failed.
The Broccoli Plugin: [SimpleConcat: Concat: Vendor Styles/assets/vendor.css] failed with:
Error: ENOENT: no such file or directory, stat '/home/amr/sandboxes/forsiapp/tmp/simple_concat-input_base_path-yY0gVCvD.tmp/0/components/growl-manager.css'
    at Error (native)
    at Object.fs.statSync (fs.js:846:18)
    at ConcatWithMaps.keyForFile (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/node_modules/broccoli-concat/node_modules/broccoli-caching-writer/index.js:90:20)
    at Array.map (native)
    at ConcatWithMaps.CachingWriter._conditionalBuild (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/node_modules/broccoli-concat/node_modules/broccoli-caching-writer/index.js:112:65)
    at /home/amr/sandboxes/forsiapp/node_modules/ember-cli/node_modules/broccoli-concat/node_modules/broccoli-caching-writer/node_modules/broccoli-plugin/read_compat.js:61:34
    at lib$rsvp$$internal$$tryCatch (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1036:16)
    at lib$rsvp$$internal$$invokeCallback (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1048:17)
    at lib$rsvp$$internal$$publish (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1019:11)
    at lib$rsvp$asap$$flush (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/node_modules/rsvp/dist/rsvp.js:1198:9)

The broccoli plugin was instantiated at: 
    at ConcatWithMaps.Plugin (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/node_modules/broccoli-concat/node_modules/broccoli-caching-writer/node_modules/broccoli-plugin/index.js:10:31)
    at ConcatWithMaps.CachingWriter (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/node_modules/broccoli-concat/node_modules/broccoli-caching-writer/index.js:21:10)
    at new ConcatWithMaps (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/node_modules/broccoli-concat/concat.js:22:17)
    at module.exports (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/node_modules/broccoli-concat/index.js:26:10)
    at EmberApp.concatFiles (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/lib/broccoli/ember-app.js:346:10)
    at EmberApp.styles (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/lib/broccoli/ember-app.js:1277:28)
    at EmberApp.toArray (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/lib/broccoli/ember-app.js:1565:10)
    at EmberApp.toTree (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/lib/broccoli/ember-app.js:1586:30)
    at module.exports (/home/amr/sandboxes/forsiapp/ember-cli-build.js:79:14)
    at Class.module.exports.Task.extend.setupBroccoliBuilder (/home/amr/sandboxes/forsiapp/node_modules/ember-cli/lib/models/builder.js:55:19)

```

This commit fixes this, and it would be most appreciated if it can be merged and put into a release? :-)
