### PR TITLE
Fix build for Ember 2

### DIFF
--- a/app/initializers/growl.js
+++ b/app/initializers/growl.js
@@ -2,7 +2,7 @@ import Growl from '../services/growl';
 
 export default {
   name: 'growl',
-  initialize: function(container, app) {
+  initialize: function(app) {
     Growl.reopenClass({
       container: container
     });

--- a/index.js
+++ b/index.js
@@ -6,6 +6,13 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import('components/growl-manager.css');
+    const versionString = app.project.pkg.dependencies['ember-cli'];
+    const version = versionString.replace(/[^\d\.]/, '');
+
+    if (version.match(/^1/)) {
+      app.import('components/growl-manager.css');
+    } else {
+      app.import('app/styles/components/growl-manager.css');
+    }
   }
 };


### PR DESCRIPTION
This is a good fix for loading the CSS file in Ember 2.

Building on:
https://github.com/jerel/ember-cli-growl/pull/9
